### PR TITLE
Fix Candy Box url (#722)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 		==================
 		
 		A minimalist text adventure by Michael Townsend and all his friends.
-		Inspired by Candy Box (http://candies.aniwey.net/)
+		Inspired by Candy Box (https://candybox2.github.io/candybox)
 		Contribute on GitHub! (https://github.com/doublespeakgames/adarkroom/)
 	-->
 	<title>A Dark Room</title>


### PR DESCRIPTION
as per https://github.com/doublespeakgames/adarkroom/issues/693 - the current Candy Box url is dead and leads to spam. This fixes the url.